### PR TITLE
Dockerコンテナ上のアプリケーションをリモートデバッグ出来ない問題を解消

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 .env
 
 /.vscode
+
+# go build output
+video-manager-go

--- a/.realize.yaml
+++ b/.realize.yaml
@@ -8,13 +8,13 @@ schema:
     commands:
       install:
         status: true
-        method: go build -o portfolio-backend
+        method: go build -o video-manager-go
       run:
         status: true
         method: /go/bin/dlv
     args:
       - exec
-      - ./portfolio-backend
+      - ./video-manager-go
       - --headless=true
       - --listen=:2345
       - --api-version=2

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY . .
 RUN set -ex && \
     apk update && \
     apk add --no-cache git && \
-    go build -o portfolio-backend && \
+    go build -o video-manager-go && \
     go get gopkg.in/urfave/cli.v2@master && \
     go get github.com/oxequa/realize && \
     go get -u github.com/go-delve/delve/cmd/dlv && \
@@ -21,11 +21,11 @@ RUN set -ex && \
 
 FROM alpine:3.10
 
-COPY --from=build /go/app/app .
+COPY --from=build /go/app/video-manager-go .
 
 RUN set -x \
     && addgroup go \
     && adduser -D -G go go \
-    && chown -R go:go /app/app
+    && chown -R go:go /app/video-manager-go
 
-CMD ["./app"]
+CMD ["./video-manager-go"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       target: build
     volumes:
       - ./:/go/src/app
-    command: realize start --run --no-config
+    command: realize start --run
     ports:
       - 8080:8080
       - 2345:2345


### PR DESCRIPTION
# 原因と修正内容
`docker-compose.yml` での `command`  の書き方が   `.realize.yaml` を無視する形になっていたので、こちらを修正する事で `github.com/go-delve/delve/cmd/dlv` を使ってアプリケーションをリモートデバッグ出来るようにしました。

GoLandですが、こちらでリモートデバッグ出来る事を確認しております。

<img width="993" alt="remote-debug-by-goland" src="https://user-images.githubusercontent.com/11032365/75443560-02393180-59a5-11ea-83c6-223f6a45b4b8.png">

お手数ですが、ご確認＆PRの取り込みをご検討ください！